### PR TITLE
Added function to set flash memory parameters

### DIFF
--- a/include/esp_loader.h
+++ b/include/esp_loader.h
@@ -167,6 +167,19 @@ esp_loader_error_t esp_loader_change_baudrate(uint32_t baudrate);
 esp_loader_error_t esp_loader_flash_verify(void);
 
 /**
+	* @brief Set SPI flash memory parameters.
+	*        Call before using esp_loader_flash_start
+	*
+	* @param total_size[in]     total size of flash memory in bytes
+	*
+	* @return
+	*     - ESP_LOADER_SUCCESS Success
+	*     - ESP_LOADER_ERROR_TIMEOUT Timeout
+	*     - ESP_LOADER_ERROR_INVALID_RESPONSE Internal error
+	*/
+esp_loader_error_t esp_loader_spi_params(uint32_t total_size);
+    
+/**
   * @brief Toggles reset pin.
   */
 void esp_loader_reset_target(void);

--- a/private_include/serial_comm.h
+++ b/private_include/serial_comm.h
@@ -52,6 +52,7 @@ esp_loader_error_t loader_change_baudrate_cmd(uint32_t baudrate);
 
 esp_loader_error_t loader_md5_cmd(uint32_t address, uint32_t size, uint8_t *md5_out);
 
+esp_loader_error_t loader_spi_parameters(uint32_t total_size);
 
 #ifdef __cplusplus
 }

--- a/private_include/serial_comm_prv.h
+++ b/private_include/serial_comm_prv.h
@@ -175,6 +175,17 @@ typedef struct __attribute__((packed))
     response_status_t status;
 } rom_md5_response_t;
 
+typedef struct __attribute__((packed))
+{
+    command_common_t common;
+    uint32_t id;
+    uint32_t total_size;
+    uint32_t block_size;
+    uint32_t sector_size;
+    uint32_t page_size;
+    uint32_t status_mask;
+} write_spi_command_t;    
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/esp_loader.c
+++ b/src/esp_loader.c
@@ -214,6 +214,13 @@ esp_loader_error_t esp_loader_flash_verify(void)
 
 #endif
 
+esp_loader_error_t esp_loader_spi_params(uint32_t total_size)
+{
+    loader_port_start_timer(DEFAULT_TIMEOUT);
+
+    return loader_spi_parameters(total_size);
+}
+
 void esp_loader_reset_target(void)
 {
     loader_port_reset_target();

--- a/src/serial_comm.c
+++ b/src/serial_comm.c
@@ -401,6 +401,26 @@ esp_loader_error_t loader_md5_cmd(uint32_t address, uint32_t size, uint8_t *md5_
     return send_cmd_md5(&md5_cmd, sizeof(md5_cmd), md5_out);
 }
 
+esp_loader_error_t loader_spi_parameters(uint32_t total_size)
+{
+    write_spi_command_t spi_cmd = {
+        .common = {
+            .direction = WRITE_DIRECTION,
+            .command = SPI_SET_PARAMS,
+            .size = 24,
+            .checksum = 0
+        },
+        .id = 0,
+        .total_size = total_size,
+        .block_size = 64 * 1024,
+        .sector_size = 4 * 1024,
+        .page_size = 0x100,
+        .status_mask = 0xFFFF,
+    };
+
+    return send_cmd(&spi_cmd, sizeof(spi_cmd), NULL);
+}
+
 __attribute__ ((weak)) void loader_port_debug_print(const char *str)
 {
 


### PR DESCRIPTION
I could not upload the AT firmware to the EPS32devkitc without setting the SPI flash memory parameters first.  So have added a `esp_loader_spi_params` function to the library.
The block, sector and page sizes are hard coded as per what esptool.py `flash_set_parameters` does.