### PR TITLE
Fix arithmetic done on void pointer

### DIFF
--- a/src/serial_comm.c
+++ b/src/serial_comm.c
@@ -218,7 +218,7 @@ static esp_loader_error_t check_response(command_t cmd, uint32_t *reg_value, voi
         }
     } while ((response->direction != READ_DIRECTION) || (response->command != cmd));
 
-    response_status_t *status = (response_status_t *)(resp + resp_size - sizeof(response_status_t));
+    response_status_t *status = (response_status_t *)((uint8_t *)resp + resp_size - sizeof(response_status_t));
 
     if (status->failed) {
         log_loader_internal_error(status->error);


### PR DESCRIPTION
Fixes this build warning:
```
  src/serial_comm.c: In function 'check_response':
  src/serial_comm.c:221:60: warning: pointer of type 'void *' used in arithmetic [-Wpointer-arith]
    221 |     response_status_t *status = (response_status_t *)(resp + resp_size - sizeof(response_status_t));
        |                                                            ^
  src/serial_comm.c:221:72: warning: pointer of type 'void *' used in arithmetic [-Wpointer-arith]
    221 |     response_status_t *status = (response_status_t *)(resp + resp_size - sizeof(response_status_t));
        |                                                                        ^
```