### PR TITLE
const-ness fixes, including a revert (ESF-31)

### DIFF
--- a/examples/common/example_common.c
+++ b/examples/common/example_common.c
@@ -214,7 +214,7 @@ esp_loader_error_t load_ram_binary(const uint8_t *bin)
 {
     printf("Start loading\n");
     esp_loader_error_t err;
-    example_bin_header_t *header = (example_bin_header_t *)bin;
+    const example_bin_header_t *header = (const example_bin_header_t *)bin;
     example_bin_segment_t segments[header->segments];
 
     // Parse segments

--- a/include/esp_loader.h
+++ b/include/esp_loader.h
@@ -148,7 +148,7 @@ esp_loader_error_t esp_loader_flash_start(uint32_t offset, uint32_t image_size, 
   *     - ESP_LOADER_ERROR_TIMEOUT Timeout
   *     - ESP_LOADER_ERROR_INVALID_RESPONSE Internal error
   */
-esp_loader_error_t esp_loader_flash_write(const void *payload, uint32_t size);
+esp_loader_error_t esp_loader_flash_write(void *payload, uint32_t size);
 
 /**
   * @brief Ends flash operation.

--- a/src/esp_loader.c
+++ b/src/esp_loader.c
@@ -261,11 +261,15 @@ esp_loader_error_t esp_loader_flash_start(uint32_t offset, uint32_t image_size, 
 }
 
 
-esp_loader_error_t esp_loader_flash_write(const void *payload, uint32_t size)
+esp_loader_error_t esp_loader_flash_write(void *payload, uint32_t size)
 {
     uint32_t padding_bytes = s_flash_write_size - size;
     uint8_t *data = (uint8_t *)payload;
     uint32_t padding_index = size;
+
+    if (size > s_flash_write_size) {
+        return ESP_LOADER_ERROR_INVALID_PARAM;
+    }
 
     while (padding_bytes--) {
         data[padding_index++] = PADDING_PATTERN;
@@ -297,7 +301,7 @@ esp_loader_error_t esp_loader_mem_start(uint32_t offset, uint32_t size, uint32_t
 
 esp_loader_error_t esp_loader_mem_write(const void *payload, uint32_t size)
 {
-    uint8_t *data = (uint8_t *)payload;
+    const uint8_t *data = (const uint8_t *)payload;
     loader_port_start_timer(timeout_per_mb(size, LOAD_RAM_TIMEOUT_PER_MB));
     return loader_mem_data_cmd(data, size);
 }

--- a/src/esp_targets.c
+++ b/src/esp_targets.c
@@ -155,7 +155,7 @@ static const esp_target_t esp_target[ESP_MAX_CHIP] = {
 
 const target_registers_t *get_esp_target_data(target_chip_t chip)
 {
-    return (target_registers_t *)&esp_target[chip];
+    return (const target_registers_t *)&esp_target[chip];
 }
 
 esp_loader_error_t loader_detect_chip(target_chip_t *target_chip, const target_registers_t **target_data)

--- a/src/serial_comm.c
+++ b/src/serial_comm.c
@@ -149,7 +149,7 @@ static esp_loader_error_t SLIP_send_delimiter(void)
 static esp_loader_error_t send_cmd(const void *cmd_data, uint32_t size, uint32_t *reg_value)
 {
     response_t response;
-    command_t command = ((command_common_t *)cmd_data)->command;
+    command_t command = ((const command_common_t *)cmd_data)->command;
 
     RETURN_ON_ERROR( SLIP_send_delimiter() );
     RETURN_ON_ERROR( SLIP_send((const uint8_t *)cmd_data, size) );
@@ -163,7 +163,7 @@ static esp_loader_error_t send_cmd_with_data(const void *cmd_data, size_t cmd_si
                                              const void *data, size_t data_size)
 {
     response_t response;
-    command_t command = ((command_common_t *)cmd_data)->command;
+    command_t command = ((const command_common_t *)cmd_data)->command;
 
     RETURN_ON_ERROR( SLIP_send_delimiter() );
     RETURN_ON_ERROR( SLIP_send((const uint8_t *)cmd_data, cmd_size) );
@@ -177,7 +177,7 @@ static esp_loader_error_t send_cmd_with_data(const void *cmd_data, size_t cmd_si
 static esp_loader_error_t send_cmd_md5(const void *cmd_data, size_t cmd_size, uint8_t md5_out[MD5_SIZE])
 {
     rom_md5_response_t response;
-    command_t command = ((command_common_t *)cmd_data)->command;
+    command_t command = ((const command_common_t *)cmd_data)->command;
 
     RETURN_ON_ERROR( SLIP_send_delimiter() );
     RETURN_ON_ERROR( SLIP_send((const uint8_t *)cmd_data, cmd_size) );


### PR DESCRIPTION
There are a few places where the c-style casts remove const-ness.
Furthermore, a recent signature change is incorrect, as the buffer passed to the function is written to with padding bytes.
A possible source of error is in the buffer's size, theoretically it could be smaller than the
flash page size, and there are no checks that the padding written to the end of buffer overruns its actual size.

I have not fixed that last observation yet!