### PR TITLE
Fixed IO0 port in loader_port_enter_bootloader (ESF-32)

### DIFF
--- a/port/stm32_port.c
+++ b/port/stm32_port.c
@@ -111,7 +111,7 @@ void loader_port_stm32_init(loader_stm32_config_t *config)
 // assert reset pin for 100 milliseconds.
 void loader_port_enter_bootloader(void)
 {
-    HAL_GPIO_WritePin(gpio_port_rst, gpio_num_io0, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(gpio_port_io0, gpio_num_io0, GPIO_PIN_RESET);
     loader_port_reset_target();
     HAL_Delay(SERIAL_FLASHER_BOOT_HOLD_TIME_MS);
     HAL_GPIO_WritePin(gpio_port_io0, gpio_num_io0, GPIO_PIN_SET);


### PR DESCRIPTION
In loader_port_enter_bootloader, the HAL_GPIO_WritePin referred to the rst port instead of the io0 port.