### PR TITLE
replace function deprecated in zephyr 3.5 (ESF-89)

### DIFF
--- a/examples/zephyr_example/src/main.c
+++ b/examples/zephyr_example/src/main.c
@@ -18,7 +18,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <zephyr_port.h>
-#include <esp_loader.h>
+#include <esp_loader_io.h>
 #include "example_common.h"
 
 #define HIGHER_BAUDRATE 230400

--- a/port/zephyr_port.c
+++ b/port/zephyr_port.c
@@ -117,7 +117,7 @@ static uint64_t s_time_end;
 
 void loader_port_start_timer(uint32_t ms)
 {
-    s_time_end = sys_clock_timeout_end_calc(Z_TIMEOUT_MS(ms));
+    s_time_end = sys_timepoint_calc(Z_TIMEOUT_MS(ms)).tick;
 }
 
 uint32_t loader_port_remaining_time(void)


### PR DESCRIPTION
Due to a deprecation warning for the currently used function, here we have implemented the recommended fix for use with Zephyr 3.5 and later. No change of functionality is incurred.