### PR TITLE
Fix compiler warnings (ESF-97)

### DIFF
--- a/private_include/protocol.h
+++ b/private_include/protocol.h
@@ -219,12 +219,6 @@ esp_loader_error_t loader_mem_data_cmd(const uint8_t *data, uint32_t size);
 
 esp_loader_error_t loader_mem_end_cmd(uint32_t entrypoint);
 
-esp_loader_error_t loader_mem_begin_cmd(uint32_t offset, uint32_t size, uint32_t blocks_to_write, uint32_t block_size);
-
-esp_loader_error_t loader_mem_data_cmd(const uint8_t *data, uint32_t size);
-
-esp_loader_error_t loader_mem_end_cmd(uint32_t entrypoint);
-
 esp_loader_error_t loader_write_reg_cmd(uint32_t address, uint32_t value, uint32_t mask, uint32_t delay_us);
 
 esp_loader_error_t loader_read_reg_cmd(uint32_t address, uint32_t *reg);

--- a/src/esp_targets.c
+++ b/src/esp_targets.c
@@ -286,6 +286,7 @@ static esp_loader_error_t spi_config_esp32xx(uint32_t efuse_base, uint32_t *spi_
 // Some newer chips like the esp32c6 do not support configurable SPI
 static esp_loader_error_t spi_config_unsupported(uint32_t efuse_base, uint32_t *spi_config)
 {
+    (void)(efuse_base); // UNUSED param
     *spi_config = 0;
     return ESP_LOADER_SUCCESS;
 }


### PR DESCRIPTION
Removes redundant declarations and suppresses unused parameter warnings so that library builds on more restrictive compilers.