### PR TITLE
Desktop support (Linux / Windows / Mac)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "submodules/stm32-cmake"]
 	path = submodules/stm32-cmake
 	url = https://github.com/ObKo/stm32-cmake.git
+[submodule "submodules/serial"]
+	path = submodules/serial
+	url = https://github.com/wjwwood/serial

--- a/examples/desktop_esp32_example/CMakeLists.txt
+++ b/examples/desktop_esp32_example/CMakeLists.txt
@@ -1,0 +1,80 @@
+set(ESPSERIAL_PATH ${CMAKE_CURRENT_LIST_DIR}/../../)
+
+# LIB serial
+
+SET(serial_path ${ESPSERIAL_PATH}submodules/serial)
+SET(serial_SRCS ${serial_path}/src/serial.cc)
+
+if(APPLE)
+    # If OSX
+    list(APPEND serial_SRCS ${serial_path}/src/impl/unix.cc)
+    list(APPEND serial_SRCS ${serial_path}/src/impl/list_ports/list_ports_osx.cc)
+elseif(UNIX)
+    # If unix
+    list(APPEND serial_SRCS ${serial_path}/src/impl/unix.cc)
+    list(APPEND serial_SRCS ${serial_path}/src/impl/list_ports/list_ports_linux.cc)
+else()
+    # If windows
+    list(APPEND serial_SRCS ${serial_path}/src/impl/win.cc)
+    list(APPEND serial_SRCS ${serial_path}/src/impl/list_ports/list_ports_win.cc)
+endif()
+
+add_library(serial
+    ${serial_SRCS}
+)
+
+target_include_directories(serial PUBLIC
+    ${serial_path}/include
+)
+
+# LIB esp_serial
+
+include(${ESPSERIAL_PATH}examples/common/bin2array.cmake)
+create_resources(${ESPSERIAL_PATH}examples/binaries/Hello-world ${CMAKE_BINARY_DIR}/binaries_1.c)
+set_property(SOURCE ${CMAKE_BINARY_DIR}/binaries_1.c PROPERTY GENERATED 1)
+create_resources(${ESPSERIAL_PATH}examples/binaries/RAM_APP ${CMAKE_BINARY_DIR}/binaries_2.c)
+set_property(SOURCE ${CMAKE_BINARY_DIR}/binaries_2.c PROPERTY GENERATED 1)
+
+
+add_library(esp_serial
+    ${ESPSERIAL_PATH}port/serial_port.cpp
+    ${ESPSERIAL_PATH}src/esp_loader.c
+    ${ESPSERIAL_PATH}src/esp_targets.c
+    ${ESPSERIAL_PATH}src/md5_hash.c
+    ${ESPSERIAL_PATH}src/slip.c
+    ${ESPSERIAL_PATH}src/protocol_uart.c
+    ${ESPSERIAL_PATH}src/protocol_common.c
+    ${CMAKE_BINARY_DIR}/binaries_1.c
+    ${CMAKE_BINARY_DIR}/binaries_2.c
+    ${ESPSERIAL_PATH}examples/common/example_common.c
+)
+
+target_include_directories(esp_serial PUBLIC
+    ${ESPSERIAL_PATH}include
+    ${ESPSERIAL_PATH}port
+    ${ESPSERIAL_PATH}examples/common
+)
+
+target_include_directories(esp_serial PRIVATE
+    ${ESPSERIAL_PATH}private_include
+)
+
+target_compile_definitions(esp_serial PUBLIC
+    -DSERIAL_FLASHER_INTERFACE_USB
+    -DMD5_ENABLED
+    -DSERIAL_FLASHER_WRITE_BLOCK_RETRIES=4
+)
+
+target_link_libraries(esp_serial PUBLIC
+    serial
+)
+
+# EXECUTABLE desktop_esp32_example
+
+add_executable(desktop_esp32_example
+    main/main.cpp
+)
+
+target_link_libraries(desktop_esp32_example PRIVATE
+    esp_serial
+)

--- a/examples/desktop_esp32_example/main/main.cpp
+++ b/examples/desktop_esp32_example/main/main.cpp
@@ -1,0 +1,62 @@
+/* Flash multiple partitions example
+
+   This example code is in the Public Domain (or CC0 licensed, at your option.)
+
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+#include "stdio.h"
+#include <string.h>
+
+#include "serial_port.h"
+#include "esp_loader.h"
+#include "esp_loader_io.h"
+extern "C" {
+#include "example_common.h"
+
+}
+
+#include "serial/serial.h"
+
+#define HIGHER_BAUDRATE 230400
+
+int main(int argv, char **argc)
+{
+    if(argv < 2) {
+        printf("Usage: %s <port>\n", argc[0]);
+        return 1;
+    }
+
+    example_binaries_t bin;
+
+    loader_serial_config_t config;
+    config.portName = argc[1];
+    // config.portName = "COM3";
+    config.baudrate = 115200;
+    config.timeout = 1000;
+
+    if (loader_port_serial_init((const loader_serial_config_t*)&config) != ESP_LOADER_SUCCESS) {
+        printf("Serial initialization failed.\n");
+        return -1;
+    }
+
+    if (connect_to_target(HIGHER_BAUDRATE) == ESP_LOADER_SUCCESS) {
+
+        get_example_binaries(esp_loader_get_target(), &bin);
+
+        printf("Loading bootloader...\n");
+        flash_binary(bin.boot.data, bin.boot.size, bin.boot.addr);
+        printf("Loading partition table...\n");
+        flash_binary(bin.part.data, bin.part.size, bin.part.addr);
+        printf("Loading app...\n");
+        flash_binary(bin.app.data,  bin.app.size,  bin.app.addr);
+        printf("Done!\n");
+    } else {
+        printf("Connect failed\n");
+        return -1;
+    }
+
+    return 0;
+}

--- a/port/serial_port.cpp
+++ b/port/serial_port.cpp
@@ -1,0 +1,169 @@
+/* Copyright 2020-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <thread>
+#include <chrono>
+#include <memory>
+#include "serial/serial.h"
+
+#include "serial_port.h"
+
+using std::chrono::high_resolution_clock;
+using std::chrono::duration_cast;
+using std::chrono::duration;
+using std::chrono::milliseconds;
+using namespace std::chrono_literals;
+
+loader_serial_config_t serial_config;
+std::unique_ptr<serial::Serial> serial_port;
+std::chrono::steady_clock::time_point serial_timer;
+uint32_t serial_timer_offset = 0;
+
+#ifdef SERIAL_FLASHER_DEBUG_TRACE
+static void transfer_debug_print(const uint8_t *data, uint16_t size, bool write)
+{
+    static bool write_prev = false;
+
+    if (write_prev != write) {
+        write_prev = write;
+        printf("\n--- %s ---\n", write ? "WRITE" : "READ");
+    }
+
+    for (uint32_t i = 0; i < size; i++) {
+        printf("%02x ", data[i]);
+    }
+}
+#endif
+
+static uint32_t s_time_end;
+
+esp_loader_error_t loader_port_write(const uint8_t *data, uint16_t size, uint32_t timeout)
+{
+    try {
+        if(!serial_port || !serial_port->isOpen())
+            return ESP_LOADER_ERROR_FAIL;
+
+        serial_port->setTimeout(serial::Timeout::simpleTimeout(timeout));
+        size_t result = serial_port->write(data, size);
+        if (result != size) {
+            return ESP_LOADER_ERROR_FAIL;
+        }
+    } catch (...) {
+        return ESP_LOADER_ERROR_FAIL;
+    }
+
+    #ifdef SERIAL_FLASHER_DEBUG_TRACE
+            transfer_debug_print(data, size, true);
+    #endif
+
+    return ESP_LOADER_SUCCESS;
+}
+
+
+esp_loader_error_t loader_port_read(uint8_t *data, uint16_t size, uint32_t timeout)
+{
+    try {
+        if(!serial_port || !serial_port->isOpen())
+            return ESP_LOADER_ERROR_FAIL;
+
+        size_t result = serial_port->read(data, size);
+        if (result != size) {
+            return ESP_LOADER_ERROR_FAIL;
+        }
+    } catch (...) {
+        return ESP_LOADER_ERROR_FAIL;
+    }
+
+    #ifdef SERIAL_FLASHER_DEBUG_TRACE
+        transfer_debug_print(data, size, true);
+    #endif
+
+    return ESP_LOADER_SUCCESS;
+}
+
+esp_loader_error_t loader_port_serial_init(const loader_serial_config_t *config)
+{
+    serial_config = *config;
+
+    try {
+        serial_port = std::make_unique<serial::Serial>(serial_config.portName, config->baudrate, serial::Timeout::simpleTimeout(config->timeout));
+        if ( serial_port->isOpen() == false ) {
+            return ESP_LOADER_ERROR_FAIL;
+        }
+    } catch (...) {
+        return ESP_LOADER_ERROR_FAIL;
+    }
+    
+    return ESP_LOADER_SUCCESS;
+}
+
+// Set GPIO0 LOW, then
+// assert reset pin for 100 milliseconds.
+void loader_port_enter_bootloader(void)
+{
+    // todo
+    loader_port_reset_target();
+}
+
+
+void loader_port_reset_target(void)
+{
+    // todo
+}
+
+
+void loader_port_delay_ms(uint32_t ms)
+{
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+}
+
+
+void loader_port_start_timer(uint32_t ms)
+{
+    serial_timer = high_resolution_clock::now();
+    serial_timer_offset = ms;
+}
+
+
+uint32_t loader_port_remaining_time(void)
+{
+    auto time_now = high_resolution_clock::now();
+    int32_t remaining = (duration_cast<milliseconds>(time_now - serial_timer - serial_timer_offset * 1ms)).count();
+    return (remaining > 0) ? (uint32_t)remaining : 0;
+}
+
+
+void loader_port_debug_print(const char *str)
+{
+    printf("DEBUG: %s", str);
+}
+
+esp_loader_error_t loader_port_change_transmission_rate(uint32_t baudrate)
+{
+    try {
+        serial_port = std::make_unique<serial::Serial>(serial_config.portName, baudrate, serial::Timeout::simpleTimeout(serial_config.timeout));
+
+        if ( serial_port->isOpen() == false ) {
+            return ESP_LOADER_ERROR_FAIL;
+        }
+    } catch (...) {
+        return ESP_LOADER_ERROR_FAIL;
+    }
+
+    return ESP_LOADER_SUCCESS;
+}

--- a/port/serial_port.h
+++ b/port/serial_port.h
@@ -1,0 +1,35 @@
+/* Copyright 2020-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "esp_loader_io.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    char* portName;
+    int baudrate;
+    int timeout;
+} loader_serial_config_t;
+
+esp_loader_error_t loader_port_serial_init(const loader_serial_config_t *config);
+
+#ifdef __cplusplus
+}
+#endif

--- a/private_include/protocol.h
+++ b/private_include/protocol.h
@@ -31,7 +31,8 @@ extern "C" {
 
 #define MD5_SIZE 32
 
-typedef enum __attribute__((packed))
+__pragma( pack(push, 1) )
+typedef enum
 {
     FLASH_BEGIN = 0x02,
     FLASH_DATA  = 0x03,
@@ -52,7 +53,7 @@ typedef enum __attribute__((packed))
     SPI_FLASH_MD5    = 0x13,
 } command_t;
 
-typedef enum __attribute__((packed))
+typedef enum
 {
     RESPONSE_OK     = 0x00,
     INVALID_COMMAND = 0x05, // parameters or length field is invalid
@@ -64,7 +65,7 @@ typedef enum __attribute__((packed))
     DEFLATE_ERROR   = 0x0b, // ESP32 compressed uploads only
 } error_code_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint8_t direction;
     uint8_t command;    // One of command_t
@@ -72,7 +73,7 @@ typedef struct __attribute__((packed))
     uint32_t checksum;
 } command_common_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     command_common_t common;
     uint32_t erase_size;
@@ -82,7 +83,7 @@ typedef struct __attribute__((packed))
     uint32_t encrypted;
 } flash_begin_command_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     command_common_t common;
     uint32_t data_size;
@@ -91,13 +92,13 @@ typedef struct __attribute__((packed))
     uint32_t zero_1;
 } data_command_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     command_common_t common;
     uint32_t stay_in_loader;
 } flash_end_command_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     command_common_t common;
     uint32_t total_size;
@@ -106,20 +107,20 @@ typedef struct __attribute__((packed))
     uint32_t offset;
 } mem_begin_command_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     command_common_t common;
     uint32_t stay_in_loader;
     uint32_t entry_point_address;
 } mem_end_command_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     command_common_t common;
     uint8_t sync_sequence[36];
 } sync_command_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     command_common_t common;
     uint32_t address;
@@ -128,27 +129,27 @@ typedef struct __attribute__((packed))
     uint32_t delay_us;
 } write_reg_command_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     command_common_t common;
     uint32_t address;
 } read_reg_command_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     command_common_t common;
     uint32_t configuration;
     uint32_t zero; // ESP32 ROM only
 } spi_attach_command_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     command_common_t common;
     uint32_t new_baudrate;
     uint32_t old_baudrate;
 } change_baudrate_command_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     command_common_t common;
     uint32_t address;
@@ -157,7 +158,7 @@ typedef struct __attribute__((packed))
     uint32_t reserved_1;
 } spi_flash_md5_command_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint8_t direction;
     uint8_t command;    // One of command_t
@@ -165,26 +166,26 @@ typedef struct __attribute__((packed))
     uint32_t value;
 } common_response_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint8_t failed;
     uint8_t error;
 } response_status_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     common_response_t common;
     response_status_t status;
 } response_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     common_response_t common;
     uint8_t md5[MD5_SIZE];     // ROM only
     response_status_t status;
 } rom_md5_response_t;
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     command_common_t common;
     uint32_t id;
@@ -194,6 +195,8 @@ typedef struct __attribute__((packed))
     uint32_t page_size;
     uint32_t status_mask;
 } write_spi_command_t;
+
+__pragma( pack(pop))
 
 esp_loader_error_t loader_initialize_conn(esp_loader_connect_args_t *connect_args);
 

--- a/src/protocol_common.c
+++ b/src/protocol_common.c
@@ -295,7 +295,7 @@ esp_loader_error_t loader_spi_parameters(uint32_t total_size)
     return send_cmd(&spi_cmd, sizeof(spi_cmd), NULL);
 }
 
-__attribute__ ((weak)) void loader_port_debug_print(const char *str)
-{
-    (void) str;
-}
+// void loader_port_debug_print(const char *str)
+// {
+//     (void) str;
+// }


### PR DESCRIPTION
For a board I made using the esp32s3 I also have a desktop client written in c++.

It would be great if users could update the firmware directly from the tool. Wanting to keep the tool small by not including a python install to use esptool, I found this library to contain the most important parts.

I've done some work to make it work on x86 systems by using the https://github.com/wjwwood/serial library.

It's not completed yet and could probably use a good eye but I wanted to share it at least so other interested people could find it.

A new example is added called: desktop_esp32_example. It builds and rust on my windows system. Have not tried flashing to an actual board yet, will have to check got esptool does the resetting since normally a PC wouldn't have gpio access.