### PR TITLE
fix: Correct flash boundary check for read/verify operations (ESF-248)

### DIFF
--- a/src/esp_loader.c
+++ b/src/esp_loader.c
@@ -609,7 +609,7 @@ static esp_loader_error_t flash_read_stub(uint8_t *dest, uint32_t address, uint3
 esp_loader_error_t esp_loader_flash_read(uint8_t *dest, uint32_t address, uint32_t length)
 {
     RETURN_ON_ERROR(init_flash_params());
-    if (address + length >= s_target_flash_size) {
+    if (address + length > s_target_flash_size) {
         return ESP_LOADER_ERROR_IMAGE_SIZE;
     }
 
@@ -810,7 +810,7 @@ esp_loader_error_t esp_loader_flash_verify_known_md5(uint32_t address,
 
     RETURN_ON_ERROR(init_flash_params());
 
-    if (address + size >= s_target_flash_size) {
+    if (address + size > s_target_flash_size) {
         return ESP_LOADER_ERROR_IMAGE_SIZE;
     }
 


### PR DESCRIPTION
The checks on read/verity used `>=` not `>` meaning last byte of flash could not
be verified or read, resulting in `ESP_LOADER_ERROR_IMAGE_SIZE` error.

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Simple boundary check issue, changed `>=` to `>` on flash size limit checks.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

Tested on 4M ESP32S3. Before change an attempt to verify after flash on last block caused `ESP_LOADER_ERROR_IMAGE_SIZE` error. Testing with fix worked correctly.

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

No need to add comment or documentation or change tests for this - it is not consistent with the flash boundary check.

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
