### PR TITLE
feat(protocol): add flash deflate write (ESF-266)

### DIFF
--- a/examples/esp32_deflate_example/CMakeLists.txt
+++ b/examples/esp32_deflate_example/CMakeLists.txt
@@ -1,0 +1,18 @@
+# The following lines of boilerplate have to be in your project's CMakeLists
+# in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.5)
+
+set(EXTRA_COMPONENT_DIRS ../../)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(esp-serial-flasher)
+
+# There are issues with ESP-IDF 4.4 and -Wunused-parameter
+if ("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER "4.4")
+    idf_component_get_property(flasher esp-serial-flasher COMPONENT_LIB)
+
+    target_compile_options(${flasher}
+    PRIVATE
+        -Wunused-parameter
+        -Wshadow
+    )
+endif()

--- a/examples/esp32_deflate_example/README.md
+++ b/examples/esp32_deflate_example/README.md
@@ -1,0 +1,99 @@
+# Flash Multiple Partitions with Compression (Deflate) Example
+
+## Overview
+
+This example demonstrates how to flash an Espressif SoC (target) from another MCU (host) using `esp_serial_flasher` with compressed data transfer. Pre-compressed binaries are transferred using the FLASH_DEFL\_\* commands (zlib-compressed) and verified with MD5.
+
+The following steps are performed in order to re-program the target's memory:
+
+1. UART1 through which the new binary will be transferred is initialized.
+2. The host puts the target device into boot mode and tries to connect and upload the flasher stub by calling `esp_loader_connect_with_stub()`. Change to connect_to_target(HIGHER_BAUDRATE) to use ROM bootloader in app_main().
+3. `esp_loader_flash_deflate_start()` is called to enter flashing mode and erase the amount of memory to be flashed.
+4. `esp_loader_flash_deflate_write()` function is called repeatedly until the whole compressed binary image is transferred.
+5. Each flashed region is verified against the original binary using MD5.
+
+## Hardware Required
+
+- Two development boards with Espressif SoCs (e.g., ESP32-DevKitC, ESP-WROVER-KIT, etc.).
+- One or two USB cables for power supply and programming.
+- Jumper cables to connect host to target according to table below.
+
+## Hardware Connection
+
+This example uses the **UART interface**. For detailed interface information and general hardware considerations, see the [Hardware Connections Guide](../../docs/hardware-connections.md#uartserial-interface).
+
+**ESP32-to-Espressif SoC Pin Assignment:**
+
+| ESP32 (host) | Espressif SoC (target) |
+| :----------: | :--------------------: |
+|     IO26     |          BOOT          |
+|     IO25     |         RESET          |
+|     IO4      |          RX0           |
+|     IO5      |          TX0           |
+
+## Prepare Target Firmware
+
+Place the required target firmware binaries in the `target-firmware/` directory, You can use your own binaries, build them from the esp-idf examples, or build them from the source in the `test/target-example-src` directory, and compress them:
+
+1. Place `bootloader.bin`, `partition-table.bin`, and `app.bin` in `target-firmware/`
+2. Run the compression script:
+   ```bash
+   cd target-firmware
+   python compress_firmware.py
+   ```
+
+This generates matching `*_deflated.bin` files for each input binary.
+
+**Required binaries (after compression):**
+
+- `bootloader.bin` and `bootloader_deflated.bin`
+- `partition-table.bin` and `partition-table_deflated.bin`
+- `app.bin` and `app_deflated.bin`
+
+> [!NOTE]
+> Both original `.bin` files (for MD5 verification) and compressed `*_deflated.bin` files (for flashing) are embedded into the host firmware.
+
+## Build and Flash
+
+To run the example, type the following command:
+
+```CMake
+idf.py -p PORT flash monitor
+```
+
+(To exit the serial monitor, type `Ctrl-]`.)
+
+See the [Getting Started Guide](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/index.html) for full steps to configure and use ESP-IDF to build projects.
+
+## Configuration
+
+For details about available configuration options, please refer to the top level [README.md](../../README.md).
+
+## Example Output
+
+Here is the example's console output:
+
+```text
+...
+I (398) main_task: Calling app_main()
+I (398) gpio: GPIO[25]| InputEn: 0| OutputEn: 0| OpenDrain: 0| Pullup: 1| Pulldown: 0| Intr:0
+I (398) gpio: GPIO[26]| InputEn: 0| OutputEn: 0| OpenDrain: 0| Pullup: 1| Pulldown: 0| Intr:0
+Connected to target
+Transmission rate changed.
+I (2148) serial_flasher_deflate: Flashing bootloader via DEFLATE (compressed size: 16355, uncompressed: 26720)...
+Progress: 100 %
+I (3268) serial_flasher_deflate: Verifying bootloader via MD5...
+I (3288) serial_flasher_deflate: bootloader MD5 matches.
+I (3288) serial_flasher_deflate: Flashing partition table via DEFLATE (compressed size: 103, uncompressed: 3072)...
+Progress: 100 %
+I (3348) serial_flasher_deflate: Verifying partition table via MD5...
+I (3358) serial_flasher_deflate: partition table MD5 matches.
+I (3358) serial_flasher_deflate: Flashing application via DEFLATE (compressed size: 83489, uncompressed: 155600)...
+Progress: 100 %
+I (7928) serial_flasher_deflate: Verifying application via MD5...
+I (8008) serial_flasher_deflate: application MD5 matches.
+I (8008) serial_flasher_deflate: All flashes verified. Success!
+I (8618) serial_flasher_deflate: ********************************************
+I (8618) serial_flasher_deflate: *** Logs below are print from slave .... ***
+I (8618) serial_flasher_deflate: *******************************************
+```

--- a/examples/esp32_deflate_example/main/CMakeLists.txt
+++ b/examples/esp32_deflate_example/main/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(srcs main.c ../../common/example_common.c)
+set(include_dirs . ../../common)
+
+idf_component_register(SRCS ${srcs}
+                       INCLUDE_DIRS ${include_dirs})
+set(target ${COMPONENT_LIB})
+
+# Embed binaries into the app using bin2array.cmake which is able to generate md5sum of the binary.
+include(${CMAKE_SOURCE_DIR}/../common/bin2array.cmake)
+create_resources(${CMAKE_SOURCE_DIR}/target-firmware ${CMAKE_BINARY_DIR}/target_firmware_data.c)
+set_property(SOURCE ${CMAKE_BINARY_DIR}/target_firmware_data.c PROPERTY GENERATED 1)
+target_sources(${target} PRIVATE ${CMAKE_BINARY_DIR}/target_firmware_data.c)

--- a/examples/esp32_deflate_example/main/main.c
+++ b/examples/esp32_deflate_example/main/main.c
@@ -1,0 +1,205 @@
+/* Deflate flash example
+
+   This example code is in the Public Domain (or CC0 licensed, at your option.)
+
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+#include <sys/param.h>
+#include <string.h>
+#include "esp_err.h"
+#include "esp_log.h"
+#include "driver/uart.h"
+#include "driver/gpio.h"
+#include "esp32_port.h"
+#include "esp_loader.h"
+#include "example_common.h"
+
+/* Embedded binary files using bin2array.cmake
+ * *_bin: Original uncompressed binary (for verification)
+ * *_deflated_bin: Pre-compressed binary (for flashing)
+ * *_bin_md5: MD5 hash as hex string (32 chars)
+ */
+extern const uint8_t bootloader_bin[];
+extern const uint32_t bootloader_bin_size;
+extern const uint8_t bootloader_deflated_bin[];
+extern const uint32_t bootloader_deflated_bin_size;
+extern const uint8_t bootloader_bin_md5[];
+extern const uint8_t partition_table_bin[];
+extern const uint32_t partition_table_bin_size;
+extern const uint8_t partition_table_deflated_bin[];
+extern const uint32_t partition_table_deflated_bin_size;
+extern const uint8_t partition_table_bin_md5[];
+extern const uint8_t app_bin[];
+extern const uint32_t app_bin_size;
+extern const uint8_t app_deflated_bin[];
+extern const uint32_t app_deflated_bin_size;
+extern const uint8_t app_bin_md5[];
+
+static const char *TAG = "serial_flasher_deflate";
+
+#define HIGHER_BAUDRATE 230400
+#define DEFLATE_BLOCK_SIZE 1024
+
+// Max line size
+#define BUF_LEN 128
+static uint8_t buf[BUF_LEN] = {0};
+
+void slave_monitor(void *arg)
+{
+#if (HIGHER_BAUDRATE != 115200)
+    uart_flush_input(UART_NUM_1);
+    uart_flush(UART_NUM_1);
+    uart_set_baudrate(UART_NUM_1, 115200);
+#endif
+    while (1) {
+        int rxBytes = uart_read_bytes(UART_NUM_1, buf, BUF_LEN - 1, 100 / portTICK_PERIOD_MS);
+        if (rxBytes > 0) {
+            buf[rxBytes] = '\0';
+            printf("%s", buf);
+        }
+    }
+}
+
+
+static esp_loader_error_t flash_deflated_binary(const uint8_t *compressed_data,
+        uint32_t compressed_size,
+        uint32_t uncompressed_size,
+        uint32_t address)
+{
+    esp_loader_error_t err;
+    static uint8_t payload[DEFLATE_BLOCK_SIZE];
+
+    err = esp_loader_flash_deflate_start(address, uncompressed_size, compressed_size, DEFLATE_BLOCK_SIZE);
+    if (err != ESP_LOADER_SUCCESS) {
+        ESP_LOGE(TAG, "Failed to start deflate flash (%d)", err);
+        return err;
+    }
+
+    uint32_t offset = 0;
+    uint32_t written = 0;
+    while (offset < compressed_size) {
+        const uint32_t to_write = MIN(compressed_size - offset, DEFLATE_BLOCK_SIZE);
+        memcpy(payload, compressed_data + offset, to_write);
+
+        err = esp_loader_flash_deflate_write(payload, to_write);
+        if (err != ESP_LOADER_SUCCESS) {
+            ESP_LOGE(TAG, "Failed to write deflate block at offset %u (%d)",
+                     (unsigned int)offset, err);
+            esp_loader_flash_deflate_finish(false);
+            return err;
+        }
+        offset += to_write;
+        written += to_write;
+
+        int progress = (int)(((float)written / compressed_size) * 100);
+        printf("\rProgress: %d %%", progress);
+    }
+    printf("\n");
+
+    err = esp_loader_flash_deflate_finish(false);
+    if (err != ESP_LOADER_SUCCESS) {
+        ESP_LOGE(TAG, "Failed to finish deflate flash (%d)", err);
+    }
+
+    return err;
+}
+
+static esp_loader_error_t flash_deflated_and_verify(const char *label,
+        const uint8_t *compressed_data,
+        uint32_t compressed_size,
+        const uint8_t *raw_md5,
+        uint32_t raw_size,
+        uint32_t address)
+{
+    esp_loader_error_t err;
+
+    ESP_LOGI(TAG, "Flashing %s via DEFLATE (compressed size: %u, uncompressed: %u)...",
+             label, (unsigned int)compressed_size, (unsigned int)raw_size);
+
+    err = flash_deflated_binary(compressed_data, compressed_size, raw_size,
+                                address);
+    if (err != ESP_LOADER_SUCCESS) {
+        ESP_LOGE(TAG, "Compressed flash failed for %s (%d)", label, err);
+        return err;
+    }
+
+    ESP_LOGI(TAG, "Verifying %s via MD5...", label);
+    err = esp_loader_flash_verify_known_md5(address, raw_size, raw_md5);
+    if (err != ESP_LOADER_SUCCESS) {
+        ESP_LOGE(TAG, "%s MD5 verification failed (%d)", label, err);
+        return err;
+    }
+
+    ESP_LOGI(TAG, "%s MD5 matches.", label);
+    return ESP_LOADER_SUCCESS;
+}
+
+void app_main(void)
+{
+    const loader_esp32_config_t config = {
+        .baud_rate = 115200,
+        .uart_port = UART_NUM_1,
+        .uart_rx_pin = GPIO_NUM_5,
+        .uart_tx_pin = GPIO_NUM_4,
+        .reset_trigger_pin = GPIO_NUM_25,
+        .gpio0_trigger_pin = GPIO_NUM_26,
+    };
+
+    if (loader_port_esp32_init(&config) != ESP_LOADER_SUCCESS) {
+        ESP_LOGE(TAG, "serial initialization failed.");
+        return;
+    }
+
+    if (connect_to_target_with_stub(115200, HIGHER_BAUDRATE) == ESP_LOADER_SUCCESS) {
+        target_chip_t chip = esp_loader_get_target();
+        uint32_t bootloader_addr = get_bootloader_address(chip);
+        uint32_t partition_addr = PARTITION_TABLE_ADDRESS;
+        uint32_t app_addr = APPLICATION_ADDRESS;
+
+        bool all_ok = true;
+        esp_loader_error_t err = flash_deflated_and_verify("bootloader",
+                                 bootloader_deflated_bin, bootloader_deflated_bin_size,
+                                 bootloader_bin_md5, bootloader_bin_size, bootloader_addr);
+        if (err != ESP_LOADER_SUCCESS) {
+            all_ok = false;
+            ESP_LOGW(TAG, "Continuing despite bootloader failure...");
+        }
+
+        err = flash_deflated_and_verify("partition table",
+                                        partition_table_deflated_bin, partition_table_deflated_bin_size,
+                                        partition_table_bin_md5, partition_table_bin_size, partition_addr);
+        if (err != ESP_LOADER_SUCCESS) {
+            all_ok = false;
+            ESP_LOGW(TAG, "Continuing despite partition table failure...");
+        }
+
+        err = flash_deflated_and_verify("application",
+                                        app_deflated_bin, app_deflated_bin_size,
+                                        app_bin_md5, app_bin_size, app_addr);
+        if (err != ESP_LOADER_SUCCESS) {
+            all_ok = false;
+            ESP_LOGW(TAG, "Continuing despite application failure...");
+        }
+
+        if (all_ok) {
+            ESP_LOGI(TAG, "All flashes verified. Success!");
+            esp_loader_reset_target();
+
+            // Delay for skipping the boot message of the targets
+            vTaskDelay(500 / portTICK_PERIOD_MS);
+
+            // Forward slave's serial output
+            ESP_LOGI(TAG, "********************************************");
+            ESP_LOGI(TAG, "*** Logs below are print from slave .... ***");
+            ESP_LOGI(TAG, "********************************************");
+            xTaskCreate(slave_monitor, "slave_monitor", 2048, NULL, configMAX_PRIORITIES - 1, NULL);
+        } else {
+            ESP_LOGE(TAG, "One or more flashes failed verification.");
+        }
+    }
+
+    vTaskDelete(NULL);
+}

--- a/examples/esp32_deflate_example/target-firmware/README.md
+++ b/examples/esp32_deflate_example/target-firmware/README.md
@@ -1,0 +1,28 @@
+# Target Firmware
+
+Place the ESP firmware binaries in this directory (for example `app.bin`,
+`bootloader.bin`, `partition-table.bin`).
+
+## Generating Pre-compressed Binary
+
+Use the provided script to compress all binaries in this directory:
+
+```bash
+python compress_firmware.py
+```
+
+This reads all `.bin` files (excluding `*_deflated.bin`) and generates
+matching `*_deflated.bin` outputs using zlib compression.
+
+You can also specify custom input/output paths:
+
+```bash
+python compress_firmware.py /path/to/input.bin /path/to/output_deflated.bin
+```
+
+If you pass a single input file, the output will be written to
+`<input>_deflated.bin`:
+
+```bash
+python compress_firmware.py app.bin
+```

--- a/examples/esp32_deflate_example/target-firmware/compress_firmware.py
+++ b/examples/esp32_deflate_example/target-firmware/compress_firmware.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# This code is in the Public Domain (or CC0 licensed, at your option.)
+
+"""
+Compress firmware binaries for deflate flashing.
+
+This script reads uncompressed .bin files and generates *_deflated.bin outputs
+which can be flashed using the deflate protocol commands.
+
+Usage:
+    python compress_firmware.py [input_file] [output_file]
+
+If no arguments provided, compresses all .bin files in the script directory
+except *_deflated.bin.
+"""
+
+import zlib
+import os
+import sys
+
+
+def compress_firmware(input_path, output_path):
+    """Compress firmware with zlib for deflate flashing."""
+    if not os.path.exists(input_path):
+        print(f"Error: {input_path} not found", file=sys.stderr)
+        return False
+
+    with open(input_path, "rb") as f:
+        data = f.read()
+
+    # Compress with best compression level
+    compressed = zlib.compress(data, 9)
+
+    with open(output_path, "wb") as f:
+        f.write(compressed)
+
+    print(f"Input:       {input_path}")
+    print(f"Input size:  {len(data)} bytes")
+    print(f"Compressed:  {len(compressed)} bytes")
+    print(f"Ratio:       {len(compressed) / len(data) * 100:.1f}%")
+    print(f"Output:      {output_path}")
+
+    return True
+
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+
+    if len(sys.argv) >= 3:
+        input_path = sys.argv[1]
+        output_path = sys.argv[2]
+        if not compress_firmware(input_path, output_path):
+            sys.exit(1)
+        return
+
+    if len(sys.argv) == 2:
+        input_path = sys.argv[1]
+        if input_path.endswith("_deflated.bin"):
+            print(f"Error: {input_path} already looks deflated", file=sys.stderr)
+            sys.exit(1)
+        output_path = f"{os.path.splitext(input_path)[0]}_deflated.bin"
+        if not compress_firmware(input_path, output_path):
+            sys.exit(1)
+        return
+
+    input_bins = sorted(
+        name
+        for name in os.listdir(script_dir)
+        if name.endswith(".bin") and not name.endswith("_deflated.bin")
+    )
+    if not input_bins:
+        print(f"Error: no input .bin files found in {script_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    for name in input_bins:
+        input_path = os.path.join(script_dir, name)
+        output_name = f"{name[:-4]}_deflated.bin"
+        output_path = os.path.join(script_dir, output_name)
+        if not compress_firmware(input_path, output_path):
+            sys.exit(1)
+        print("")
+
+
+if __name__ == "__main__":
+    main()

--- a/include/esp_loader.h
+++ b/include/esp_loader.h
@@ -228,6 +228,65 @@ esp_loader_error_t esp_loader_flash_write(void *payload, uint32_t size);
   */
 esp_loader_error_t esp_loader_flash_finish(bool reboot);
 
+/* Compressed flash download is not yet supported by SDIO interface */
+#if (defined SERIAL_FLASHER_INTERFACE_UART) || (defined SERIAL_FLASHER_INTERFACE_USB)
+
+/**
+  * @brief Initiates compressed flash operation (DEFLATE/zlib stream).
+  *
+  * @param offset[in]          Address from which flash operation will be
+  *                            performed. Must be 4 byte aligned.
+  * @param image_size[in]      Size of the uncompressed data in bytes.
+  *                            Must be 4 byte aligned.
+  * @param compressed_size[in] Size of the compressed data in bytes.
+  * @param block_size[in]      Size of each compressed block sent in
+  *                            esp_loader_flash_deflate_write().
+  *
+  * @note The compressed stream must use zlib headers (zlib.compress()).
+  *
+  * @return
+  *     - ESP_LOADER_SUCCESS Success
+  *     - ESP_LOADER_ERROR_TIMEOUT Timeout
+  *     - ESP_LOADER_ERROR_IMAGE_SIZE Image exceeds flash size
+  *     - ESP_LOADER_ERROR_INVALID_PARAM Invalid parameter
+  *     - ESP_LOADER_ERROR_UNSUPPORTED_FUNC Unsupported on the target
+  */
+esp_loader_error_t esp_loader_flash_deflate_start(uint32_t offset,
+        uint32_t image_size,
+        uint32_t compressed_size,
+        uint32_t block_size);
+
+/**
+  * @brief Writes a compressed data block to target flash memory.
+  *
+  * @param payload[in] Data buffer containing a zlib-compressed block.
+  * @param size[in]    Size of payload in bytes (must not exceed block_size).
+  *
+  * @note  size must not be greater than block_size supplied to previously called
+  *        esp_loader_flash_deflate_start function.
+  *
+  * @return
+  *     - ESP_LOADER_SUCCESS Success
+  *     - ESP_LOADER_ERROR_TIMEOUT Timeout
+  *     - ESP_LOADER_ERROR_INVALID_PARAM Invalid parameter
+  *     - ESP_LOADER_ERROR_INVALID_RESPONSE Internal error
+  */
+esp_loader_error_t esp_loader_flash_deflate_write(void *payload, uint32_t size);
+
+/**
+  * @brief Ends compressed flash operation.
+  *
+  * @param reboot[in] reboot the target if true.
+  *
+  * @return
+  *     - ESP_LOADER_SUCCESS Success
+  *     - ESP_LOADER_ERROR_TIMEOUT Timeout
+  *     - ESP_LOADER_ERROR_INVALID_RESPONSE Internal error
+  */
+esp_loader_error_t esp_loader_flash_deflate_finish(bool reboot);
+
+#endif /* SERIAL_FLASHER_INTERFACE_UART || SERIAL_FLASHER_INTERFACE_USB */
+
 /**
   * @brief Detects the size of the flash chip used by target
   *

--- a/private_include/protocol.h
+++ b/private_include/protocol.h
@@ -279,6 +279,13 @@ esp_loader_error_t loader_flash_data_cmd(const uint8_t *data, uint32_t size);
 
 esp_loader_error_t loader_flash_end_cmd(bool stay_in_loader);
 
+esp_loader_error_t loader_flash_deflate_begin_cmd(uint32_t offset, uint32_t erase_size, uint32_t block_size,
+        uint32_t blocks_to_write, bool encryption);
+
+esp_loader_error_t loader_flash_deflate_data_cmd(const uint8_t *data, uint32_t size);
+
+esp_loader_error_t loader_flash_deflate_end_cmd(bool stay_in_loader);
+
 #ifndef SERIAL_FLASHER_INTERFACE_SPI
 esp_loader_error_t loader_md5_cmd(uint32_t address, uint32_t size, uint8_t *md5_out);
 

--- a/src/esp_loader.c
+++ b/src/esp_loader.c
@@ -409,6 +409,67 @@ esp_loader_error_t esp_loader_flash_finish(bool reboot)
     return loader_flash_end_cmd(!reboot);
 }
 
+/* Compressed flash download is not yet supported by SDIO interface */
+#if (defined SERIAL_FLASHER_INTERFACE_UART) || (defined SERIAL_FLASHER_INTERFACE_USB)
+
+esp_loader_error_t esp_loader_flash_deflate_start(uint32_t offset, uint32_t image_size,
+        uint32_t compressed_size, uint32_t block_size)
+{
+    s_flash_write_size = block_size;
+
+    // Address must be aligned to 4 bytes
+    if (offset % 4 != 0) {
+        return ESP_LOADER_ERROR_INVALID_PARAM;
+    }
+
+    // ESP8266 ROM does not support deflate
+    if (s_target == ESP8266_CHIP && !esp_stub_get_running()) {
+        return ESP_LOADER_ERROR_UNSUPPORTED_FUNC;
+    }
+
+    RETURN_ON_ERROR(init_flash_params());
+    if (image_size + offset > s_target_flash_size) {
+        return ESP_LOADER_ERROR_IMAGE_SIZE;
+    }
+
+    bool encryption_in_cmd = encryption_in_begin_flash_cmd(s_target) && !esp_stub_get_running();
+    const uint32_t erase_size = calc_erase_size(esp_loader_get_target(), offset, image_size);
+    const uint32_t blocks_to_write = (compressed_size + block_size - 1) / block_size;
+
+    loader_port_start_timer(timeout_per_mb(erase_size, ERASE_FLASH_TIMEOUT_PER_MB));
+    return loader_flash_deflate_begin_cmd(offset, erase_size, block_size, blocks_to_write, encryption_in_cmd);
+}
+
+
+esp_loader_error_t esp_loader_flash_deflate_write(void *payload, uint32_t size)
+{
+    if (size > s_flash_write_size) {
+        return ESP_LOADER_ERROR_INVALID_PARAM;
+    }
+
+    unsigned int attempt = 0;
+    esp_loader_error_t result = ESP_LOADER_ERROR_FAIL;
+    do {
+        loader_port_start_timer(DEFAULT_TIMEOUT);
+        result = loader_flash_deflate_data_cmd(payload, size);
+        attempt++;
+    } while (result != ESP_LOADER_SUCCESS && attempt < SERIAL_FLASHER_WRITE_BLOCK_RETRIES);
+
+    return result;
+}
+
+
+esp_loader_error_t esp_loader_flash_deflate_finish(bool reboot)
+{
+    if (!reboot && !esp_stub_get_running()) {
+        return ESP_LOADER_SUCCESS;
+    }
+
+    loader_port_start_timer(DEFAULT_TIMEOUT);
+    return loader_flash_deflate_end_cmd(!reboot);
+}
+#endif /* SERIAL_FLASHER_INTERFACE_UART || SERIAL_FLASHER_INTERFACE_USB */
+
 esp_loader_error_t esp_loader_flash_erase(void)
 {
     if (esp_stub_get_running()) {

--- a/src/protocol_serial.c
+++ b/src/protocol_serial.c
@@ -137,6 +137,81 @@ esp_loader_error_t loader_flash_end_cmd(bool stay_in_loader)
     return send_cmd(&cmd_config);
 }
 
+esp_loader_error_t loader_flash_deflate_begin_cmd(uint32_t offset,
+        uint32_t erase_size,
+        uint32_t block_size,
+        uint32_t blocks_to_write,
+        bool encryption)
+{
+    flash_begin_command_t flash_begin_cmd = {
+        .common = {
+            .direction = WRITE_DIRECTION,
+            .command = FLASH_DEFL_BEGIN,
+            .size = CMD_SIZE(flash_begin_cmd) - (encryption ? 0 : sizeof(uint32_t)),
+            .checksum = 0
+        },
+        .erase_size = erase_size,
+        .packet_count = blocks_to_write,
+        .packet_size = block_size,
+        .offset = offset,
+        .encrypted = 0
+    };
+
+    s_sequence_number = 0;
+
+    const send_cmd_config cmd_config = {
+        .cmd = &flash_begin_cmd,
+        .cmd_size = sizeof(flash_begin_cmd) - (encryption ? 0 : sizeof(uint32_t)),
+    };
+
+    return send_cmd(&cmd_config);
+}
+
+
+esp_loader_error_t loader_flash_deflate_data_cmd(const uint8_t *data, uint32_t size)
+{
+    data_command_t data_cmd = {
+        .common = {
+            .direction = WRITE_DIRECTION,
+            .command = FLASH_DEFL_DATA,
+            .size = CMD_SIZE(data_cmd) + size,
+            .checksum = compute_checksum(data, size)
+        },
+        .data_size = size,
+        .sequence_number = s_sequence_number++,
+    };
+
+    const send_cmd_config cmd_config = {
+        .cmd = &data_cmd,
+        .cmd_size = sizeof(data_cmd),
+        .data = data,
+        .data_size = size,
+    };
+
+    return send_cmd(&cmd_config);
+}
+
+
+esp_loader_error_t loader_flash_deflate_end_cmd(bool stay_in_loader)
+{
+    flash_end_command_t end_cmd = {
+        .common = {
+            .direction = WRITE_DIRECTION,
+            .command = FLASH_DEFL_END,
+            .size = CMD_SIZE(end_cmd),
+            .checksum = 0
+        },
+        .stay_in_loader = stay_in_loader
+    };
+
+    const send_cmd_config cmd_config = {
+        .cmd = &end_cmd,
+        .cmd_size = sizeof(end_cmd)
+    };
+
+    return send_cmd(&cmd_config);
+}
+
 
 esp_loader_error_t loader_flash_read_rom_cmd(const uint32_t address, uint8_t *data)
 {


### PR DESCRIPTION
## Description

Add support for flashing **pre-compressed (deflate) binaries** via the ROM/stub “Compressed Flash Download” protocol (FLASH_DEFL_* commands).

Changes:
- Add deflate API to `esp_loader.h`:
  - `esp_loader_flash_deflate_start()`
  - `esp_loader_flash_deflate_write()`
  - `esp_loader_flash_deflate_finish()`
- Implement FLASH_DEFL_BEGIN / FLASH_DEFL_DATA / FLASH_DEFL_END in `protocol_serial.c`
- Add `esp32_deflate_example` showing usage
- Add `test/deflate` validating Python zlib ↔ ROM miniz compatibility

## Related

Fixes #83

## Testing

- [x] `esp32_deflate_example`: (board + steps/command output here)
- [x] `test/deflate`: (how you ran it + result here)

---

## Checklist

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.